### PR TITLE
require hookextras module where needed

### DIFF
--- a/lua/autorun/server/jester_buddha.lua
+++ b/lua/autorun/server/jester_buddha.lua
@@ -1,5 +1,7 @@
 -- The Jester role gains buddha to certain damage types
 
+require("hookextras")
+
 util.OnInitialize(function()
 	local buddhaDamageTypes = {
 		[DMG_BURN] = true,

--- a/lua/autorun/tttmeta.lua
+++ b/lua/autorun/tttmeta.lua
@@ -2,6 +2,9 @@
 -- No longer required: if engine.ActiveGamemode() ~= "terrortown" then return end
 
 local Tag = "tttfix"
+
+require("hookextras")
+
 local emptyFunc = function() end
 
 AOWL_NO_TEAMS = true

--- a/lua/autorun/weapon_tweaks.lua
+++ b/lua/autorun/weapon_tweaks.lua
@@ -1,6 +1,8 @@
 -- Manual SWEP tweaks
 -- Use this file to apply manual tweaks and fixes onto a weapon, without having to overwrite said weapon's entire lua file
 
+require("hookextras")
+
 util.OnInitialize(function()
 	local SWEP
 


### PR DESCRIPTION
from glua_utilities#helpers branch
we don't want to assume that it's already loaded by some other script